### PR TITLE
Check path only if path reinstate successfully when reinstating path …

### DIFF
--- a/multipathd/cli_handlers.c
+++ b/multipathd/cli_handlers.c
@@ -888,6 +888,7 @@ cli_reinstate(void * v, char ** reply, int * len, void * data)
 	struct vectors * vecs = (struct vectors *)data;
 	char * param = get_keyparam(v, PATH);
 	struct path * pp;
+	int r;
 
 	param = convert_dev(param, 1);
 	pp = find_path_by_dev(vecs->pathvec, param);
@@ -901,8 +902,14 @@ cli_reinstate(void * v, char ** reply, int * len, void * data)
 	condlog(2, "%s: reinstate path %s (operator)",
 		pp->mpp->alias, pp->dev_t);
 
-	checker_enable(&pp->checker);
-	return dm_reinstate_path(pp->mpp->alias, pp->dev_t);
+	r = dm_reinstate_path(pp->mpp->alias, pp->dev_t);
+	/*
+	 * Check path only if reinstat path successfull
+	 */
+	if (!r)
+		checker_enable(&pp->checker);
+	
+	return r;
 }
 
 int


### PR DESCRIPTION
…by CLI

We fail a path, and suspend the map which the path belongs to, then reinstate the path by CLI and it returned with a fail message, the problem is: 1) There is a lot of messages that indicate the path status is up but reinstate fail; 2) When we resume the map, the path change status to active from failed automatically though it's failed when we reinstated path before.