### PR TITLE
Fix systemd build requirements (bsc#983167)

### DIFF
--- a/rpm/multipath-tools.spec
+++ b/rpm/multipath-tools.spec
@@ -21,7 +21,8 @@ BuildRequires:  device-mapper-devel
 BuildRequires:  libaio-devel
 BuildRequires:  libudev-devel
 BuildRequires:  readline-devel
-BuildRequires:  systemd-devel
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  udev
 Url:            http://christophe.varoqui.free.fr/
 Requires:       device-mapper >= 1.2.78


### PR DESCRIPTION
pkgconfig() should be used instead of relying on package names which
might change.

Also systemd.pc is not shipped by systemd-devel package anymore. Since
it's needed during the build of multipath-tools (not really sure why)
explicitly require it.