### PR TITLE
update multipath rules to deal with partition devices

### DIFF
--- a/multipath/multipath.rules
+++ b/multipath/multipath.rules
@@ -1,14 +1,22 @@
 # Set DM_MULTIPATH_DEVICE_PATH if the device should be handled by multipath
 SUBSYSTEM!="block", GOTO="end_mpath"
+ACTION!="add|change", GOTO="end_mpath"
+KERNEL!="sd*|dasd*", GOTO="end_mpath"
+
+ENV{DEVTYPE}!="partition", GOTO="test_dev"
+IMPORT{parent}="DM_MULTIPATH_DEVICE_PATH"
+ENV{DM_MULTIPATH_DEVICE_PATH}=="1", ENV{ID_FS_TYPE}="none", \
+	ENV{SYSTEMD_READY}="0"
+GOTO="end_mpath"
+
+LABEL="test_dev"
 
 ENV{MPATH_SBIN_PATH}="/sbin"
 TEST!="$env{MPATH_SBIN_PATH}/multipath", ENV{MPATH_SBIN_PATH}="/usr/sbin"
 
-SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="sd*[!0-9]|dasd*[!0-9]", \
-	ENV{DM_MULTIPATH_DEVICE_PATH}!="1", \
-	PROGRAM=="$env{MPATH_SBIN_PATH}/multipath -i -u %k", \
-	ENV{DM_MULTIPATH_DEVICE_PATH}="1" \
-	ENV{ID_FS_TYPE}="none" \
+ENV{DM_MULTIPATH_DEVICE_PATH}!="1", \
+	PROGRAM=="$env{MPATH_SBIN_PATH}/multipath -u %k", \
+	ENV{DM_MULTIPATH_DEVICE_PATH}="1", ENV{ID_FS_TYPE}="none", \
 	ENV{SYSTEMD_READY}="0"
 
 LABEL="end_mpath"


### PR DESCRIPTION
Partition devices should inherit the DM_MULTIPATH_DEVICE_PATH
state of their parents, and if they are part of multipath path devices,
they shouldn't have their own ID_FS_TYPE

Signed-off-by: Benjamin Marzinski <bmarzins@redhat.com>